### PR TITLE
Upgrade xwalk.gradle for new gradle version

### DIFF
--- a/platforms/android/xwalk.gradle
+++ b/platforms/android/xwalk.gradle
@@ -169,10 +169,19 @@ cdvPluginPostBuildExtras.add({
         def variantName = variant.name.capitalize()
         def mergeTask = tasks["merge${variantName}Assets"]
         def processTask = tasks["process${variantName}Resources"]
-        def outFile = new File (mergeTask.outputDir, "xwalk-command-line")
-        def newTask = project.task("createXwalkCommandLineFile${variantName}") << {
-            mergeTask.outputDir.mkdirs()
-            outFile.write("xwalk ${xwalkCommandLine}\n")
+        def outputDir = mergeTask.outputDir
+        File directory
+        if (outputDir instanceof File) {
+            directory = outputDir
+        } else {
+            directory = outputDir.get().asFile
+        }
+        def outFile = new File (directory.toString(), "xwalk-command-line")
+        def newTask = project.task("createXwalkCommandLineFile${variantName}") {
+            doLast {
+                directory.mkdirs()
+                outFile.write("xwalk ${xwalkCommandLine}\n")
+            }
         }
         newTask.dependsOn(mergeTask)
         processTask.dependsOn(newTask)


### PR DESCRIPTION
With the latest cordova-android version, 
1 mergeTask.outputDir is not type File, needs to be converted
2 left shift << is not supported, needs to be replaced with "doLast"